### PR TITLE
feat: run integration and example tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,9 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       id-token: write
       contents: read
@@ -359,7 +361,9 @@ jobs:
     name: Example Tests
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary

Enable the `integration-tests` and `example-tests` CI jobs to run on pull requests, not just on pushes to the main branch.

## Problem

Currently, these test jobs only run after code is merged to main:
- `integration-tests` - Tests all scenarios in `test/` against real AWS API
- `example-tests` - Tests all example scenarios in `examples/`

This means issues aren't caught until after merge, requiring hotfixes or reverts.

## Solution

Modified the `if` conditions for both jobs to also run on pull requests from the same repository:

```yaml
if: |
  (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
  (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
```

## Benefits

✅ **Earlier feedback** - Catch AWS API integration issues before merge  
✅ **Validate examples** - Ensure example scenarios work correctly  
✅ **Safer merges** - More confidence that PRs won't break main  
✅ **Security maintained** - Only runs for PRs from same repo (not forks)

## Security Considerations

The jobs require AWS credentials via OIDC:
- Only runs for PRs from the same repository
- Fork PRs will skip these jobs (can't access secrets)
- Uses short-lived credentials via `id-token: write` permission

This prevents malicious fork PRs from accessing AWS credentials.

## Testing

The changes only modify the job conditions. The test execution logic remains unchanged:
- **Integration tests**: Uses existing `test/run-tests.sh` script
- **Example tests**: Uses existing inline bash script in workflow

## Changes

- Modified `.github/workflows/ci.yml` job conditions for:
  - `integration-tests` job
  - `example-tests` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)